### PR TITLE
Adding state to oauth get_auth_url response

### DIFF
--- a/hubspot/utils/oauth.py
+++ b/hubspot/utils/oauth.py
@@ -1,13 +1,14 @@
 import urllib
 
 
-def get_auth_url(client_id, redirect_uri, scopes: tuple, optional_scopes=()):
+def get_auth_url(client_id, redirect_uri, scopes: tuple, optional_scopes=(), state=""):
     return "https://app.hubspot.com/oauth/authorize?" + urllib.parse.urlencode(
         {
             "client_id": client_id,
             "redirect_uri": redirect_uri,
             "scope": " ".join(scopes),
             "optional_scope": " ".join(optional_scopes),
+            "state": state,
         },
         quote_via=urllib.parse.quote,
     )


### PR DESCRIPTION
This let's us use the State parameter: https://legacydocs.hubspot.com/docs/methods/oauth2/initiate-oauth-integration. This is useful for CSRF protection and restoring to the proper app state after a successful auth.