### PR TITLE
Iss#24 readme links

### DIFF
--- a/sample-apps/companies-app/README.md
+++ b/sample-apps/companies-app/README.md
@@ -21,7 +21,7 @@ Please see the documentation on [Creating an app in HubSpot](https://developers.
   - [Delete associations between company and contacts](https://developers.hubspot.com/docs/api/crm/associations)
 
 ### Note on Application Scopes
-HubSpot provides a way to restrict application users access to the system to certain scopes. In order to do that it is a good practice to make a set of scopes required by your applicatuion.
+HubSpot provides a way to restrict application users access to the system to certain scopes. In order to do that it is a good practice to make a set of scopes required by your application.
 Please refer to [Initiate an Integration with OAuth 2.0](https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration) for documentation on the scope parameter passed to https://app.hubspot.com/oauth/authorize to make a set of scopes required. [Scopes](https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration#scopes) explains how to make optional scopes and talks about scopes available in HubSpot system
 
 ### Setup App

--- a/sample-apps/companies-app/README.md
+++ b/sample-apps/companies-app/README.md
@@ -1,24 +1,24 @@
 # HubSpot-python sample Companies app
 
 This is a sample app for the [hubspot-python SDK](../../../../).
-Currently, this app focuses on demonstrating the functionality of [Companies API](https://developers.hubspot.com/docs/crm/companies) endpoints and their related actions.
+Currently, this app focuses on demonstrating the functionality of [Companies API](https://developers.hubspot.com/docs/api/crm/companies) endpoints and their related actions.
 
-Please see the documentation on [Creating an app in HubSpot](https://developers.hubspot.com/docs/creating-an-app)
+Please see the documentation on [Creating an app in HubSpot](https://developers.hubspot.com/docs/api/creating-an-app)
 
 ### HubSpot Public API links used in this application
 
-  - [Create a company object](https://developers.hubspot.com/docs/crm/companies)
-  - [Update a company](https://developers.hubspot.com/docs/crm/companies)
-  - [Search for companies by domain](https://developers.hubspot.com/docs/crm/companies)
-  - [Get companies](https://developers.hubspot.com/docs/crm/companies)
-  - [Get all company properties](https://developers.hubspot.com/docs/crm/properties)
-  - [Get a company](https://developers.hubspot.com/docs/crm/companies)
-  - [Get associated contacts at a company](https://developers.hubspot.com/docs/crm/associations)
-  - [Read a batch of contact objects by ID](https://developers.hubspot.com/docs/crm/companies)
-  - [Get all contacts](https://developers.hubspot.com/docs/crm/contacts)
-  - [Search for contacts](https://developers.hubspot.com/docs/crm/contacts)
-  - [Create associations between company and contacts](https://developers.hubspot.com/docs/crm/associations)
-  - [Delete associations between company and contacts](https://developers.hubspot.com/docs/crm/associations)
+  - [Create a company object](https://developers.hubspot.com/docs/api/crm/companies)
+  - [Update a company](https://developers.hubspot.com/docs/api/crm/companies)
+  - [Search for companies by domain](https://developers.hubspot.com/docs/api/crm/companies)
+  - [Get companies](https://developers.hubspot.com/docs/api/crm/companies)
+  - [Get all company properties](https://developers.hubspot.com/docs/api/crm/properties)
+  - [Get a company](https://developers.hubspot.com/docs/api/crm/companies)
+  - [Get associated contacts at a company](https://developers.hubspot.com/docs/api/crm/contacts)
+  - [Read a batch of contact objects by ID](https://developers.hubspot.com/docs/api/crm/companies)
+  - [Get all contacts](https://developers.hubspot.com/docs/api/crm/contacts)
+  - [Search for contacts](https://developers.hubspot.com/docs/api/crm/contacts)
+  - [Create associations between company and contacts](https://developers.hubspot.com/docs/api/crm/associations)
+  - [Delete associations between company and contacts](https://developers.hubspot.com/docs/api/crm/associations)
 
 ### Note on Application Scopes
 HubSpot provides a way to restrict application users access to the system to certain scopes. In order to do that it is a good practice to make a set of scopes required by your applicatuion.

--- a/sample-apps/companies-app/README.md
+++ b/sample-apps/companies-app/README.md
@@ -13,7 +13,7 @@ Please see the documentation on [Creating an app in HubSpot](https://developers.
   - [Get companies](https://developers.hubspot.com/docs/api/crm/companies)
   - [Get all company properties](https://developers.hubspot.com/docs/api/crm/properties)
   - [Get a company](https://developers.hubspot.com/docs/api/crm/companies)
-  - [Get associated contacts at a company](https://developers.hubspot.com/docs/api/crm/contacts)
+  - [Get associated contacts at a company](https://developers.hubspot.com/docs/api/crm/associations)
   - [Read a batch of contact objects by ID](https://developers.hubspot.com/docs/api/crm/companies)
   - [Get all contacts](https://developers.hubspot.com/docs/api/crm/contacts)
   - [Search for contacts](https://developers.hubspot.com/docs/api/crm/contacts)


### PR DESCRIPTION
Should resolve issue #24 

Links now correctly direct the user to the appropriate API documentation page for the given task. Links to Docker, and to HubSpot OAuth Integration pages (ln25) were tested and worked fine.

Also, there was a small typo towards the bottom of the README (`applicatuion` -> `application`).

Let me know of inaccuracies or adjustments needing made; cheers!