### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/hubspot/cms/blogs/blog_posts/models/blog_post.py
+++ b/hubspot/cms/blogs/blog_posts/models/blog_post.py
@@ -503,7 +503,7 @@ class BlogPost(object):
     def state(self):
         """Gets the state of this BlogPost.  # noqa: E501
 
-        An ENUM descibing the current state of this Blog Post.  # noqa: E501
+        An ENUM describing the current state of this Blog Post.  # noqa: E501
 
         :return: The state of this BlogPost.  # noqa: E501
         :rtype: str
@@ -514,7 +514,7 @@ class BlogPost(object):
     def state(self, state):
         """Sets the state of this BlogPost.
 
-        An ENUM descibing the current state of this Blog Post.  # noqa: E501
+        An ENUM describing the current state of this Blog Post.  # noqa: E501
 
         :param state: The state of this BlogPost.  # noqa: E501
         :type: str
@@ -2438,7 +2438,7 @@ class BlogPost(object):
     def content_type_category(self):
         """Gets the content_type_category of this BlogPost.  # noqa: E501
 
-        An ENUM descibing the type of this object. Should always be BLOG_POST.  # noqa: E501
+        An ENUM describing the type of this object. Should always be BLOG_POST.  # noqa: E501
 
         :return: The content_type_category of this BlogPost.  # noqa: E501
         :rtype: str
@@ -2449,7 +2449,7 @@ class BlogPost(object):
     def content_type_category(self, content_type_category):
         """Sets the content_type_category of this BlogPost.
 
-        An ENUM descibing the type of this object. Should always be BLOG_POST.  # noqa: E501
+        An ENUM describing the type of this object. Should always be BLOG_POST.  # noqa: E501
 
         :param content_type_category: The content_type_category of this BlogPost.  # noqa: E501
         :type: str
@@ -2478,7 +2478,7 @@ class BlogPost(object):
     def current_state(self):
         """Gets the current_state of this BlogPost.  # noqa: E501
 
-        A generated ENUM descibing the current state of this Blog Post. Should always match state.  # noqa: E501
+        A generated ENUM describing the current state of this Blog Post. Should always match state.  # noqa: E501
 
         :return: The current_state of this BlogPost.  # noqa: E501
         :rtype: str
@@ -2489,7 +2489,7 @@ class BlogPost(object):
     def current_state(self, current_state):
         """Sets the current_state of this BlogPost.
 
-        A generated ENUM descibing the current state of this Blog Post. Should always match state.  # noqa: E501
+        A generated ENUM describing the current state of this Blog Post. Should always match state.  # noqa: E501
 
         :param current_state: The current_state of this BlogPost.  # noqa: E501
         :type: str

--- a/hubspot/cms/hubdb/api/tables_api.py
+++ b/hubspot/cms/hubdb/api/tables_api.py
@@ -1811,7 +1811,7 @@ class TablesApi(object):
     ):  # noqa: E501
         """Update an existing table  # noqa: E501
 
-        Update an existing HubDB table. You can use this endpoint to add or remove columns to the table. Tables updated using the endpoint will only modify the `draft` verion of the table. Use `push-live` endpoint to push all the changes to the `live` version. **Note:** You need to include all the columns in the input when you are adding/removing/updating a column. If you do not include an already existing column in the request, it will be deleted.  # noqa: E501
+        Update an existing HubDB table. You can use this endpoint to add or remove columns to the table. Tables updated using the endpoint will only modify the `draft` version of the table. Use `push-live` endpoint to push all the changes to the `live` version. **Note:** You need to include all the columns in the input when you are adding/removing/updating a column. If you do not include an already existing column in the request, it will be deleted.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_draft_table(table_id_or_name, hub_db_table_v3_input, async_req=True)
@@ -1842,7 +1842,7 @@ class TablesApi(object):
     ):  # noqa: E501
         """Update an existing table  # noqa: E501
 
-        Update an existing HubDB table. You can use this endpoint to add or remove columns to the table. Tables updated using the endpoint will only modify the `draft` verion of the table. Use `push-live` endpoint to push all the changes to the `live` version. **Note:** You need to include all the columns in the input when you are adding/removing/updating a column. If you do not include an already existing column in the request, it will be deleted.  # noqa: E501
+        Update an existing HubDB table. You can use this endpoint to add or remove columns to the table. Tables updated using the endpoint will only modify the `draft` version of the table. Use `push-live` endpoint to push all the changes to the `live` version. **Note:** You need to include all the columns in the input when you are adding/removing/updating a column. If you do not include an already existing column in the request, it will be deleted.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_draft_table_with_http_info(table_id_or_name, hub_db_table_v3_input, async_req=True)

--- a/hubspot/crm/companies/api/batch_api.py
+++ b/hubspot/crm/companies/api/batch_api.py
@@ -444,7 +444,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of companies  # noqa: E501
 
-        Perform a partial upate on a batch of companies. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of companies. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(batch_input_simple_public_object_batch_input, async_req=True)
@@ -473,7 +473,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of companies  # noqa: E501
 
-        Perform a partial upate on a batch of companies. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of companies. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/contacts/api/batch_api.py
+++ b/hubspot/crm/contacts/api/batch_api.py
@@ -444,7 +444,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of contacts  # noqa: E501
 
-        Perform a partial upate on a batch of contacts. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of contacts. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(batch_input_simple_public_object_batch_input, async_req=True)
@@ -473,7 +473,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of contacts  # noqa: E501
 
-        Perform a partial upate on a batch of contacts. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of contacts. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/deals/api/batch_api.py
+++ b/hubspot/crm/deals/api/batch_api.py
@@ -444,7 +444,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of deals  # noqa: E501
 
-        Perform a partial upate on a batch of deals. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of deals. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(batch_input_simple_public_object_batch_input, async_req=True)
@@ -473,7 +473,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of deals  # noqa: E501
 
-        Perform a partial upate on a batch of deals. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of deals. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/line_items/api/batch_api.py
+++ b/hubspot/crm/line_items/api/batch_api.py
@@ -444,7 +444,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of line items  # noqa: E501
 
-        Perform a partial upate on a batch of line items. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of line items. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(batch_input_simple_public_object_batch_input, async_req=True)
@@ -473,7 +473,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of line items  # noqa: E501
 
-        Perform a partial upate on a batch of line items. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of line items. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/objects/api/batch_api.py
+++ b/hubspot/crm/objects/api/batch_api.py
@@ -490,7 +490,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of objects  # noqa: E501
 
-        Perform a partial upate on a batch of objects. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of objects. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(object_type, batch_input_simple_public_object_batch_input, async_req=True)
@@ -520,7 +520,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of objects  # noqa: E501
 
-        Perform a partial upate on a batch of objects. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of objects. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(object_type, batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/products/api/batch_api.py
+++ b/hubspot/crm/products/api/batch_api.py
@@ -444,7 +444,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of products  # noqa: E501
 
-        Perform a partial upate on a batch of products. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of products. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(batch_input_simple_public_object_batch_input, async_req=True)
@@ -473,7 +473,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of products  # noqa: E501
 
-        Perform a partial upate on a batch of products. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of products. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/tickets/api/batch_api.py
+++ b/hubspot/crm/tickets/api/batch_api.py
@@ -444,7 +444,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of tickets  # noqa: E501
 
-        Perform a partial upate on a batch of tickets. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of tickets. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update(batch_input_simple_public_object_batch_input, async_req=True)
@@ -473,7 +473,7 @@ class BatchApi(object):
     ):  # noqa: E501
         """Update a batch of tickets  # noqa: E501
 
-        Perform a partial upate on a batch of tickets. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
+        Perform a partial update on a batch of tickets. This follows the same rules as performing partial updates on an individual object.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_with_http_info(batch_input_simple_public_object_batch_input, async_req=True)

--- a/hubspot/crm/timeline/models/timeline_event.py
+++ b/hubspot/crm/timeline/models/timeline_event.py
@@ -233,7 +233,7 @@ class TimelineEvent(object):
     def timestamp(self):
         """Gets the timestamp of this TimelineEvent.  # noqa: E501
 
-        The time the event occurred. If not passed in, the curren time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
+        The time the event occurred. If not passed in, the current time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
 
         :return: The timestamp of this TimelineEvent.  # noqa: E501
         :rtype: datetime
@@ -244,7 +244,7 @@ class TimelineEvent(object):
     def timestamp(self, timestamp):
         """Sets the timestamp of this TimelineEvent.
 
-        The time the event occurred. If not passed in, the curren time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
+        The time the event occurred. If not passed in, the current time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
 
         :param timestamp: The timestamp of this TimelineEvent.  # noqa: E501
         :type: datetime

--- a/hubspot/crm/timeline/models/timeline_event_response.py
+++ b/hubspot/crm/timeline/models/timeline_event_response.py
@@ -271,7 +271,7 @@ class TimelineEventResponse(object):
     def timestamp(self):
         """Gets the timestamp of this TimelineEventResponse.  # noqa: E501
 
-        The time the event occurred. If not passed in, the curren time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
+        The time the event occurred. If not passed in, the current time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
 
         :return: The timestamp of this TimelineEventResponse.  # noqa: E501
         :rtype: datetime
@@ -282,7 +282,7 @@ class TimelineEventResponse(object):
     def timestamp(self, timestamp):
         """Sets the timestamp of this TimelineEventResponse.
 
-        The time the event occurred. If not passed in, the curren time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
+        The time the event occurred. If not passed in, the current time will be assumed. This is used to determine where an event is shown on a CRM object's timeline.  # noqa: E501
 
         :param timestamp: The timestamp of this TimelineEventResponse.  # noqa: E501
         :type: datetime

--- a/hubspot/marketing/transactional/models/public_single_send_request_egg.py
+++ b/hubspot/marketing/transactional/models/public_single_send_request_egg.py
@@ -101,7 +101,7 @@ class PublicSingleSendRequestEgg(object):
     def contact_properties(self):
         """Gets the contact_properties of this PublicSingleSendRequestEgg.  # noqa: E501
 
-        The contactProperties field is a map of contact property values. Each contact property value contains a name and value property. Each property will get set on the contact record and will be visible in the template under {{ contact.NAME }}. Use these properties when you want to set a contact property while you’re sending the email. For example, when sending a reciept you may want to set a last_paid_date property, as the sending of the receipt will have information about the last payment.  # noqa: E501
+        The contactProperties field is a map of contact property values. Each contact property value contains a name and value property. Each property will get set on the contact record and will be visible in the template under {{ contact.NAME }}. Use these properties when you want to set a contact property while you’re sending the email. For example, when sending a receipt you may want to set a last_paid_date property, as the sending of the receipt will have information about the last payment.  # noqa: E501
 
         :return: The contact_properties of this PublicSingleSendRequestEgg.  # noqa: E501
         :rtype: dict(str, str)
@@ -112,7 +112,7 @@ class PublicSingleSendRequestEgg(object):
     def contact_properties(self, contact_properties):
         """Sets the contact_properties of this PublicSingleSendRequestEgg.
 
-        The contactProperties field is a map of contact property values. Each contact property value contains a name and value property. Each property will get set on the contact record and will be visible in the template under {{ contact.NAME }}. Use these properties when you want to set a contact property while you’re sending the email. For example, when sending a reciept you may want to set a last_paid_date property, as the sending of the receipt will have information about the last payment.  # noqa: E501
+        The contactProperties field is a map of contact property values. Each contact property value contains a name and value property. Each property will get set on the contact record and will be visible in the template under {{ contact.NAME }}. Use these properties when you want to set a contact property while you’re sending the email. For example, when sending a receipt you may want to set a last_paid_date property, as the sending of the receipt will have information about the last payment.  # noqa: E501
 
         :param contact_properties: The contact_properties of this PublicSingleSendRequestEgg.  # noqa: E501
         :type: dict(str, str)


### PR DESCRIPTION
https://github.com/codespell-project/codespell --> `codespell --ignore-words-list="fo,nd,querys,seh,te" .`

`querys` is a typo for `queries` but given that it is a widely used _function parameter_, we add it to the `ignore-words-list`.