### PR TITLE
Simplify with six.integer_types

### DIFF
--- a/hubspot/auth/oauth/rest.py
+++ b/hubspot/auth/oauth/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/automation/actions/rest.py
+++ b/hubspot/automation/actions/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/audit_logs/rest.py
+++ b/hubspot/cms/audit_logs/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/blogs/authors/rest.py
+++ b/hubspot/cms/blogs/authors/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/blogs/blog_posts/rest.py
+++ b/hubspot/cms/blogs/blog_posts/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/blogs/tags/rest.py
+++ b/hubspot/cms/blogs/tags/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/domains/rest.py
+++ b/hubspot/cms/domains/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/hubdb/rest.py
+++ b/hubspot/cms/hubdb/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/performance/rest.py
+++ b/hubspot/cms/performance/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/site_search/rest.py
+++ b/hubspot/cms/site_search/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/cms/url_redirects/rest.py
+++ b/hubspot/cms/url_redirects/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/conversations/visitor_identification/rest.py
+++ b/hubspot/conversations/visitor_identification/rest.py
@@ -152,9 +152,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/associations/rest.py
+++ b/hubspot/crm/associations/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/companies/rest.py
+++ b/hubspot/crm/companies/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/contacts/rest.py
+++ b/hubspot/crm/contacts/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/deals/rest.py
+++ b/hubspot/crm/deals/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/extensions/accounting/rest.py
+++ b/hubspot/crm/extensions/accounting/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/extensions/calling/rest.py
+++ b/hubspot/crm/extensions/calling/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/extensions/cards/rest.py
+++ b/hubspot/crm/extensions/cards/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/extensions/videoconferencing/rest.py
+++ b/hubspot/crm/extensions/videoconferencing/rest.py
@@ -152,9 +152,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/imports/rest.py
+++ b/hubspot/crm/imports/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/line_items/rest.py
+++ b/hubspot/crm/line_items/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/objects/feedback_submissions/rest.py
+++ b/hubspot/crm/objects/feedback_submissions/rest.py
@@ -152,9 +152,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/objects/rest.py
+++ b/hubspot/crm/objects/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/owners/rest.py
+++ b/hubspot/crm/owners/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/pipelines/rest.py
+++ b/hubspot/crm/pipelines/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/products/rest.py
+++ b/hubspot/crm/products/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/properties/rest.py
+++ b/hubspot/crm/properties/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/quotes/rest.py
+++ b/hubspot/crm/quotes/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/schemas/rest.py
+++ b/hubspot/crm/schemas/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/tickets/rest.py
+++ b/hubspot/crm/tickets/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/crm/timeline/rest.py
+++ b/hubspot/crm/timeline/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/events/rest.py
+++ b/hubspot/events/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/marketing/transactional/rest.py
+++ b/hubspot/marketing/transactional/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(

--- a/hubspot/webhooks/rest.py
+++ b/hubspot/webhooks/rest.py
@@ -149,9 +149,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(
-                _request_timeout, (int,) if six.PY3 else (int, long)
-            ):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(


### PR DESCRIPTION
https://six.readthedocs.io/#six.integer_types
https://github.com/benjaminp/six/blob/master/six.py#L40-L50

This improves readability while removing several flake8 errors and will make it possible for `pyupgrade` to automatically convert the code to be Python 3 only.