### PR TITLE
Add support for 'id_property' for CRM Contacts Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - OneOfHubSpotFormDefinition model changed to HubSpotFormDefinition
+- CRM Contacts Endpoint - Added support for `id_property` (See the developer docs section [Unique identifiers and deduplication](https://developers.hubspot.com/docs/api/crm/contacts))
 
 ## [5.0.0](https://github.com/HubSpot/hubspot-api-python/compare/v4.0.6...v5.0.0) - 2022-04-12
 

--- a/hubspot/crm/contacts/api/basic_api.py
+++ b/hubspot/crm/contacts/api/basic_api.py
@@ -261,6 +261,8 @@ class BasicApi(object):
         :param list[str] properties_with_history: A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
         :param list[str] associations: A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored.
         :param bool archived: Whether to return only results that have been archived.
+        :param str id_property: The name of a property whose values are unique for this object type
+                                This param can be used exclusively with "email" value
         :param _preload_content: if False, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Default is True.
@@ -290,6 +292,8 @@ class BasicApi(object):
         :param list[str] properties_with_history: A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
         :param list[str] associations: A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored.
         :param bool archived: Whether to return only results that have been archived.
+        :param str id_property: The name of a property whose values are unique for this object type
+                                This param can be used exclusively with "email" value
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -306,7 +310,7 @@ class BasicApi(object):
 
         local_var_params = locals()
 
-        all_params = ["contact_id", "properties", "properties_with_history", "associations", "archived"]  # noqa: E501
+        all_params = ["contact_id", "properties", "properties_with_history", "associations", "archived", "id_property"]  # noqa: E501
         all_params.append("async_req")
         all_params.append("_return_http_data_only")
         all_params.append("_preload_content")
@@ -315,6 +319,8 @@ class BasicApi(object):
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
                 raise ApiTypeError("Got an unexpected keyword argument '%s'" " to method get_by_id" % key)
+            if key == "id_property" and val != "email":
+                raise ApiValueError("Got an unexpected value for keyword argument 'id_property'. Can only be used with 'email'")
             local_var_params[key] = val
         del local_var_params["kwargs"]
         # verify the required parameter 'contact_id' is set
@@ -339,6 +345,8 @@ class BasicApi(object):
             collection_formats["associations"] = "multi"  # noqa: E501
         if "archived" in local_var_params and local_var_params["archived"] is not None:  # noqa: E501
             query_params.append(("archived", local_var_params["archived"]))  # noqa: E501
+        if "id_property" in local_var_params and local_var_params["id_property"] is not None:  # noqa: E501
+            query_params.append(("idProperty", local_var_params["id_property"]))  # noqa: E501
 
         header_params = {}
 
@@ -507,6 +515,8 @@ class BasicApi(object):
         :param async_req bool: execute request asynchronously
         :param str contact_id: (required)
         :param SimplePublicObjectInput simple_public_object_input: (required)
+        :param str id_property: The name of a property whose values are unique for this object type
+                                This param can be used exclusively with "email" value
         :param _preload_content: if False, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Default is True.
@@ -533,6 +543,8 @@ class BasicApi(object):
         :param async_req bool: execute request asynchronously
         :param str contact_id: (required)
         :param SimplePublicObjectInput simple_public_object_input: (required)
+        :param str id_property: The name of a property whose values are unique for this object type
+                                This param can be used exclusively with "email" value
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -549,7 +561,7 @@ class BasicApi(object):
 
         local_var_params = locals()
 
-        all_params = ["contact_id", "simple_public_object_input"]  # noqa: E501
+        all_params = ["contact_id", "simple_public_object_input", "id_property"]  # noqa: E501
         all_params.append("async_req")
         all_params.append("_return_http_data_only")
         all_params.append("_preload_content")
@@ -558,6 +570,8 @@ class BasicApi(object):
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
                 raise ApiTypeError("Got an unexpected keyword argument '%s'" " to method update" % key)
+            if key == "id_property" and val != "email":
+                raise ApiValueError("Got an unexpected value for keyword argument 'id_property'. Can only be used with 'email'")
             local_var_params[key] = val
         del local_var_params["kwargs"]
         # verify the required parameter 'contact_id' is set
@@ -574,6 +588,8 @@ class BasicApi(object):
             path_params["contactId"] = local_var_params["contact_id"]  # noqa: E501
 
         query_params = []
+        if "id_property" in local_var_params and local_var_params["id_property"] is not None:  # noqa: E501
+            query_params.append(("idProperty", local_var_params["id_property"]))  # noqa: E501
 
         header_params = {}
 


### PR DESCRIPTION
Developer [docs](https://developers.hubspot.com/docs/api/crm/contacts) says it can be used with the `email` value.