### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -19,8 +19,8 @@ jobs:
       - run: black --check . || true
       - run: codespell --ignore-words-list="fo,nd,querys,seh,te" || true  # --skip="*.css,*.js,*.lock"
       - run: flake8 . --count --ignore=B006,C409,C417,E302,F401,W291,W292,W293,W605,YTT202
-                      --max-complexity=21 --max-line-length=208 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=21 --max-line-length=208
+                      --max-complexity=27 --max-line-length=208 --show-source --statistics
+      - run: flake8 . --count --exit-zero --max-complexity=27 --max-line-length=208
                       --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install --editable .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -28,5 +28,5 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest tests
       - run: pytest --doctest-modules . || pytest . || true
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: shopt -s globstar && pyupgrade --py37-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,30 @@
+name: lint_python
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
+                         flake8-comprehensions isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101,B105,B107 .
+      - run: black --check . || true
+      - run: codespell --ignore-words-list="fo,nd,querys,seh,te" || true  # --skip="*.css,*.js,*.lock"
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
+                      --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install --editable . || pip install . || true
+      - run: mkdir --parents --verbose .mypy_cache
+      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest --doctest-modules . || pytest . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.x
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
-                         flake8-comprehensions, isort mypy pytest pyupgrade safety
+                         flake8-comprehensions isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B105,B107 .
       - run: black --check . || true
       - run: codespell --ignore-words-list="fo,nd,querys,seh,te" || true  # --skip="*.css,*.js,*.lock"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -19,7 +19,7 @@ jobs:
       - run: black --check . || true
       - run: codespell --ignore-words-list="fo,nd,querys,seh,te" || true  # --skip="*.css,*.js,*.lock"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200
                       --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install --editable . || pip install . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,12 +14,13 @@ jobs:
           python-version: 3.x
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
-                         isort mypy pytest pyupgrade safety  # flake8-comprehensions 
+                         flake8-comprehensions, isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B105,B107 .
       - run: black --check . || true
       - run: codespell --ignore-words-list="fo,nd,querys,seh,te" || true  # --skip="*.css,*.js,*.lock"
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=208
+      - run: flake8 . --count --ignore=B006,C409,C417,E302,F401,W291,W292,W293,W605,YTT202
+                      --max-complexity=21 --max-line-length=208 --show-source --statistics
+      - run: flake8 . --count --exit-zero --max-complexity=21 --max-line-length=208
                       --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install --editable .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,17 +14,18 @@ jobs:
           python-version: 3.x
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade safety
+                         isort mypy pytest pyupgrade safety  # flake8-comprehensions 
       - run: bandit --recursive --skip B101,B105,B107 .
       - run: black --check . || true
       - run: codespell --ignore-words-list="fo,nd,querys,seh,te" || true  # --skip="*.css,*.js,*.lock"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=208
                       --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install --editable . || pip install . || true
+      - run: pip install --editable .
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest tests
       - run: pytest --doctest-modules . || pytest . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check


### PR DESCRIPTION
A more rigorous replacement for `pythonapp.yml`

flake8 issues:
```
46    B006 Do not use mutable data structures for argument defaults.  They are created during function
           definition time. All calls to the function reuse this one instance of that data structure,
           persisting changes between them.
92    C409 Unnecessary list passed to tuple() - rewrite as a tuple literal.
868   C417 Unnecessary use of map - use a list comprehension instead.
5     E302 expected 2 blank lines, found 1
13    F401 '.client.Client' imported but unused
4     W291 trailing whitespace
2     W292 no newline at end of file
2     W293 blank line contains whitespace
14    W605 invalid escape sequence '\d'
138   YTT202 `six.PY3` referenced (python4), use `not six.PY2`
1184
```