### PR TITLE
Enable oauth2 in get_by_id_with_http_info and get_page_with_http_info

### DIFF
--- a/hubspot/crm/imports/api/core_api.py
+++ b/hubspot/crm/imports/api/core_api.py
@@ -332,7 +332,7 @@ class CoreApi(object):
         header_params["Accept"] = self.api_client.select_header_accept(["application/json", "*/*"])  # noqa: E501
 
         # Authentication setting
-        auth_settings = ["hapikey"]  # noqa: E501
+        auth_settings = ["hapikey", "oauth2"]  # noqa: E501
 
         return self.api_client.call_api(
             "/crm/v3/imports/{importId}",
@@ -442,7 +442,7 @@ class CoreApi(object):
         header_params["Accept"] = self.api_client.select_header_accept(["application/json", "*/*"])  # noqa: E501
 
         # Authentication setting
-        auth_settings = ["hapikey"]  # noqa: E501
+        auth_settings = ["hapikey", "oauth2"]  # noqa: E501
 
         return self.api_client.call_api(
             "/crm/v3/imports/",


### PR DESCRIPTION
Enabled oauth2 authentication for 'imports' endpoints:

- get_by_id_with_http_info
- get_page_with_http_info