### PR TITLE
Corrected v7.1.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/HubSpot/hubspot-api-python/compare/v7.1.0...HEAD)
 
-## [7.1.0](https://github.com/HubSpot/hubspot-api-python/compare/v7.0.0...v7.1.0) - 2022-12-17
+## [7.1.0](https://github.com/HubSpot/hubspot-api-python/compare/v7.0.0...v7.1.0) - 2022-12-07
 
 ### Changed
 


### PR DESCRIPTION
We're upgrading to v7.1.0 and noticed that the release date was somehow in the future. It looks like December 7 was entered as December 17 somehow so this fixes that

In this PR:

- Corrected v7.1.0 release date