### PR TITLE
add missing basic_api to discovery

### DIFF
--- a/hubspot/discovery/crm/associations/v4/discovery.py
+++ b/hubspot/discovery/crm/associations/v4/discovery.py
@@ -4,6 +4,10 @@ from ....discovery_base import DiscoveryBase
 
 class Discovery(DiscoveryBase):
     @property
+    def basic_api(self) -> api_client.BasicApi:
+        return self._configure_api_client(api_client, "BasicApi")
+
+    @property
     def batch_api(self) -> api_client.BatchApi:
         return self._configure_api_client(api_client, "BatchApi")
 

--- a/tests/spec/crm/v4/test_v4_associations.py
+++ b/tests/spec/crm/v4/test_v4_associations.py
@@ -1,8 +1,9 @@
 from hubspot import HubSpot
-from hubspot.crm.associations.v4 import BatchApi
+from hubspot.crm.associations.v4 import BatchApi, BasicApi
 
 
 def test_is_discoverable():
     apis = HubSpot().crm.associations.v4
     assert isinstance(apis.batch_api, BatchApi)
+    assert isinstance(apis.basic_api, BasicApi)
     assert hasattr(apis, "schema")


### PR DESCRIPTION
- add missing associations.v4.basic_api to discovery with tests