### PR TITLE
Remove pkg_resources dependency

### DIFF
--- a/hubspot/discovery/discovery_base.py
+++ b/hubspot/discovery/discovery_base.py
@@ -1,4 +1,9 @@
-import pkg_resources
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 
 class DiscoveryBase:
@@ -24,7 +29,7 @@ class DiscoveryBase:
 
         api_client = api_client_package.ApiClient(configuration=configuration)
 
-        package_version = pkg_resources.require("hubspot-api-client")[0].version
+        package_version = importlib_metadata.version("hubspot-api-client")
         api_client.user_agent = "hubspot-api-client-python; {0}".format(package_version)
 
         return getattr(api_client_package, api_name)(api_client=api_client)


### PR DESCRIPTION
pkg_resources is deprecated. See https://setuptools.pypa.io/en/latest/pkg_resources.html

> Use of pkg_resources is deprecated in favor of importlib.resources, importlib.metadata and their backports (importlib_resources, importlib_metadata).

Fixes #256
