### PR TITLE
Fix Proxy Support

### DIFF
--- a/hubspot/discovery/discovery_base.py
+++ b/hubspot/discovery/discovery_base.py
@@ -21,7 +21,11 @@ class DiscoveryBase:
             configuration.retries = config["retry"]
         if "verify_ssl" in config:
             configuration.verify_ssl = config["verify_ssl"]
-
+        if "proxy" in config:
+            configuration.proxy = config["proxy"]
+        if "proxy_headers" in config:
+            configuration.proxy_headers = config["proxy_headers"]
+    
         api_client = api_client_package.ApiClient(configuration=configuration)
 
         package_version = pkg_resources.require("hubspot-api-client")[0].version

--- a/tests/spec/proxy/test_proxy.py
+++ b/tests/spec/proxy/test_proxy.py
@@ -1,0 +1,23 @@
+from hubspot import HubSpot
+from hubspot.auth.oauth import AccessTokensApi, RefreshTokensApi, TokensApi
+
+
+def test_is_discoverable():
+    proxy = "https://localhost:9000"
+    proxy_headers = {'x': 'y'}
+
+    api_client = HubSpot(proxy=proxy, proxy_headers=proxy_headers)
+    
+    assert "proxy" in api_client.config
+    assert "proxy_headers" in api_client.config
+    
+    assert api_client.config["proxy"] == proxy
+    assert api_client.config["proxy_headers"] == proxy_headers
+
+    apis = api_client.auth.oauth
+
+    assert "proxy" in apis.config
+    assert "proxy_headers" in apis.config
+    
+    assert apis.config["proxy"] == proxy
+    assert apis.config["proxy_headers"] == proxy_headers


### PR DESCRIPTION
# Issue
Proxy configurations are ignored.

# Fix
- Include `proxy` & `proxy_headers` if provided while creating Hubspot api client
- Test case is provided