### PR TITLE
Update required Python version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install --upgrade hubspot-api-client
 
 ### Requirements
 
-Make sure you have [Python 3.5+](https://docs.python.org/3/) and [pip](https://pypi.org/project/pip/) installed.
+Make sure you have [Python 3.7+](https://docs.python.org/3/) and [pip](https://pypi.org/project/pip/) installed.
 
 
 ## Quickstart


### PR DESCRIPTION
Support for Python versions lower than 3.7 was dropped in version 6.0.0 of the package. See 83047c5bce13b1ec60e8a3bc76465adc841f8892