### PR TITLE
fix: the correct attribute is 'scope' not 'scopes' in auth_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ except ApiException as e:
 from hubspot.utils.oauth import get_auth_url
 
 auth_url = get_auth_url(
-    scopes=('contacts',),
+    scope=('contacts',),
     client_id='client_id',
     redirect_uri='http://localhost'
 )


### PR DESCRIPTION
In the README, the example to get the OAuth url is wrong, it uses the 'scopes' attribute which does not exist, the correct attribute name is 'scope'.

```python
from hubspot.utils.oauth import get_auth_url

auth_url = get_auth_url(
    scope=('contacts',),
    client_id='client_id',
    redirect_uri='http://localhost'
)
```