### PR TITLE
Update urllib3 required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ NAME = "hubspot-api-client"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15, < 2.0", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.15, <= 2.0", "six >= 1.10", "certifi", "python-dateutil"]
 DEV_REQUIRES = ["pytest", "black"]
 
 DIR_PATH = dirname(abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ NAME = "hubspot-api-client"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.15, < 2.0", "six >= 1.10", "certifi", "python-dateutil"]
 DEV_REQUIRES = ["pytest", "black"]
 
 DIR_PATH = dirname(abspath(__file__))


### PR DESCRIPTION
Update urllib3 requirement version to fix issues with urllib3 2.1.0


With the latest release of urlib3 (v2.1.0) 

The `HTTPResponse.getheaders()` method is replaced in favor of `HTTPResponse.headers`

The `HTTPResponse.getheader(name, default)` is replaced in favor of `HTTPResponse.headers.get(name, default)`.

https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#what-are-the-important-changes

For now the Hubspot Api client is only compatible with version prior to 2.1.0.
