### PR TITLE
Fix/pkg resources

### DIFF
--- a/hubspot/discovery/discovery_base.py
+++ b/hubspot/discovery/discovery_base.py
@@ -1,4 +1,7 @@
-import importlib.metadata
+try:
+    import importlib.metadata as metadata
+except ImportError:
+    import importlib_metadata as metadata
 
 
 class DiscoveryBase:
@@ -24,7 +27,7 @@ class DiscoveryBase:
 
         api_client = api_client_package.ApiClient(configuration=configuration)
 
-        package_version = importlib.metadata.version("hubspot-api-client")
+        package_version = metadata.version("hubspot-api-client")
         api_client.user_agent = "hubspot-api-client-python; {0}".format(package_version)
 
         return getattr(api_client_package, api_name)(api_client=api_client)

--- a/hubspot/discovery/discovery_base.py
+++ b/hubspot/discovery/discovery_base.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.metadata
 
 
 class DiscoveryBase:
@@ -24,7 +24,7 @@ class DiscoveryBase:
 
         api_client = api_client_package.ApiClient(configuration=configuration)
 
-        package_version = pkg_resources.require("hubspot-api-client")[0].version
+        package_version = importlib.metadata.version("hubspot-api-client")
         api_client.user_agent = "hubspot-api-client-python; {0}".format(package_version)
 
         return getattr(api_client_package, api_name)(api_client=api_client)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,13 @@ NAME = "hubspot-api-client"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = [
+    "urllib3 >= 1.15",
+    "six >= 1.10",
+    "certifi",
+    "python-dateutil",
+    "importlib-metadata<5; python_version<'3.8'"
+]
 DEV_REQUIRES = ["pytest", "black"]
 
 DIR_PATH = dirname(abspath(__file__))


### PR DESCRIPTION
Replace deprecated `pkg_resources` with `importlib` while maintaining support for Python < 3.8