### PR TITLE
Relax urllib3 requirements to allow the latest major version to be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ NAME = "hubspot-api-client"
 
 REQUIRES = [
     "requests >= 2.31.0",
-    "urllib3 >= 1.15, < 2.0",
+    "urllib3 >= 1.15, < 3.0",
     "six >= 1.10, < 2.0",
     "certifi >= 2023.1.1",
     "python-dateutil >= 2.8.2",


### PR DESCRIPTION
I'm not sure if there was a good reason for #352 to prevent installing the latest version of requests (I can't see one), so this relaxes this restriction. Thank you.